### PR TITLE
Version 2.2

### DIFF
--- a/functions/kdijkstra_cost.py
+++ b/functions/kdijkstra_cost.py
@@ -38,6 +38,7 @@ class Function(FunctionBase):
         resultNodesTextAnnotations = canvasItemList['annotations']
         for anno in resultNodesTextAnnotations:
             anno.setVisible(False)
+            self.iface.mapCanvas().scene().removeItem(anno)
         canvasItemList['annotations'] = []
     
     def getQuery(self, args):
@@ -146,6 +147,8 @@ class Function(FunctionBase):
             
             textAnnotation.update()
             resultNodesTextAnnotations.append(textAnnotation)
+            canvasItemList['annotations'] = resultNodesTextAnnotations
+
     
     def __init__(self, ui):
         FunctionBase.__init__(self, ui)

--- a/pgRoutingLayer.py
+++ b/pgRoutingLayer.py
@@ -215,8 +215,8 @@ class PgRoutingLayer:
         self.iface.addDockWidget(Qt.LeftDockWidgetArea, self.dock)
         
     def unload(self):
-        self.saveSettings()
         self.clear()
+        self.saveSettings()
         # Remove the plugin menu item and icon
         self.iface.removePluginDatabaseMenu("&pgRouting Layer", self.action)
         self.iface.removeDockWidget(self.dock)

--- a/pgRoutingLayer.py
+++ b/pgRoutingLayer.py
@@ -869,8 +869,10 @@ class PgRoutingLayer:
         for anno in self.canvasItemList['annotations']:
             try:
                 anno.setVisible(False)
+                self.iface.mapCanvas().scene().removeItem(anno)
             except RuntimeError, e:
-                Utils.logMessage("anno.setVisible(False) failed, " + e.message, QgsMessageLog.WARNING)
+                QApplication.restoreOverrideCursor()
+                QMessageBox.critical(self.dock, self.dock.windowTitle(), '%s' % e)
         self.canvasItemList['annotations'] = []
         for path in self.canvasItemList['paths']:
             path.reset(Utils.getRubberBandType(False))

--- a/pgRoutingLayer.py
+++ b/pgRoutingLayer.py
@@ -203,11 +203,11 @@ class PgRoutingLayer:
         self.dock.lineEditDistance.setValidator(QDoubleValidator())
         self.dock.lineEditAlpha.setValidator(QDoubleValidator())
         self.dock.lineEditPaths.setValidator(QIntValidator())
-        self.loadSettings()
         
         #populate the combo with connections
         self.reloadMessage = False
         self.reloadConnections()
+        self.loadSettings()
         Utils.logMessage("startup version " + str(self.version))
         self.reloadMessage = True
         
@@ -1204,7 +1204,7 @@ class PgRoutingLayer:
     
     def loadSettings(self):
         settings = QSettings()
-        idx = self.dock.comboConnections.findText(Utils.getStringValue(settings, '/pgRoutingLayer/Database', ''))
+        idx = self.dock.comboConnections.findText(settings.value('/pgRoutingLayer/Database', type=str))
         if idx >= 0:
             self.dock.comboConnections.setCurrentIndex(idx)
         idx = self.dock.comboBoxFunction.findText(Utils.getStringValue(settings, '/pgRoutingLayer/Function', 'dijkstra'))


### PR DESCRIPTION

- Deprecated functions don't show on versions where it has being deprecated
- Using the BBOX is optional
- works from pgRouting v2.0 to v2.5 with a high probability of working for the work on progress v2.6

## TODO

- [ ] Add the changes on the change log
