### PR TITLE
Updated alphashape.py to use BBOX

### DIFF
--- a/functions/alphashape.py
+++ b/functions/alphashape.py
@@ -48,7 +48,7 @@ class Function(FunctionBase):
                         %(target)s::int4 AS target,
                         %(cost)s::float8 AS cost%(reverse_cost)s
                         FROM %(edge_table)s
-						%(where_clause)s',
+			%(where_clause)s',
                         %(source_id)s, %(distance)s,
                         %(directed)s, %(has_reverse_cost)s)
                 ),
@@ -74,7 +74,7 @@ class Function(FunctionBase):
                         %(target)s AS target,
                         %(cost)s AS cost%(reverse_cost)s
                         FROM %(edge_table)s
-						%(where_clause)s',
+			%(where_clause)s',
                         %(source_id)s, %(distance)s,
                         %(directed)s)
                 ),
@@ -101,7 +101,7 @@ class Function(FunctionBase):
                         %(target)s::int4 AS target,
                         %(cost)s::float8 AS cost%(reverse_cost)s
                         FROM %(edge_table)s
-						%(where_clause)s',
+			%(where_clause)s',
                         %(source_id)s, %(distance)s,
                         %(directed)s, %(has_reverse_cost)s)
                 ),
@@ -124,7 +124,7 @@ class Function(FunctionBase):
                         %(target)s AS target,
                         %(cost)s AS cost%(reverse_cost)s
                         FROM %(edge_table)s
-						%(where_clause)s',
+			%(where_clause)s',
                         %(source_id)s, %(distance)s,
                         %(directed)s)
                 ),
@@ -136,8 +136,6 @@ class Function(FunctionBase):
                 )
                 SELECT * FROM node$$::text)
                 """ % args
-
-
 
 
 

--- a/functions/alphashape.py
+++ b/functions/alphashape.py
@@ -14,7 +14,7 @@ class Function(FunctionBase):
     
     @classmethod
     def getControlNames(self, version):
-        self.version = version	
+        self.version = version
         return self.commonControls + self.commonBoxes + [
             'labelId', 'lineEditId',
             'labelSource', 'lineEditSource',


### PR DESCRIPTION
I was getting errors when running alphashape.py against pgRouting 2.5.2, PostgreSQL 9.6.6 and PostGIS 2.3.5 complaining about using `&& BBOX` in the query.  I have updated the python file to match the other functions and present the BBOX check box to the user in the UI.  The queries have also been updated to take this into account.