### PR TITLE
Enable Github Pages for docs

### DIFF
--- a/docs/CNAME
+++ b/docs/CNAME
@@ -1,0 +1,1 @@
+qgis.pgrouting.org


### PR DESCRIPTION
I would suggest to enable Github Pages using the `/docs` directory way in the master branch.
This is new and looks better than a `gh-pages` branch as it keeps code and docs (site) together.
https://github.com/pgRouting/admin/issues/18

After merging this PR, the site should be accessible at https://qgis.pgrouting.org and I would suggest to use Markdown (and not Restructured Text to write the documents.