### PR TITLE
fixed mkdocs nav file

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -5,8 +5,15 @@ nav:
   - Main buttons: intro/buttons.md
   - Layer naming convention: intro/layer_naming_convention.md
 - Functions:
-  - Djikstra: functions/pgr_dijkstra.md
-  - Astar: functions/pgr_astar.md
-  - bdDijkstra: functions/pgr_bddijkstra.md
-  - bdAstar: functions/pgr_bdastar.md
+  - pgr_djikstra: functions/pgr_dijkstra.md
+  - pgr_astar: functions/pgr_astar.md
+  - pgr_alphaShape: functions/pgr_alphaShape.md
+  - pgr_bdAstar: functions/pgr_bdAstar.md
+  - pgr_bdDijkstra: functions/pgr_bdDijkstra.md
+  - pgr_drivingDistance: functions/pgr_drivingDistance.md
+  - pgr_KSP: functions/pgr_KSP.md
+  - pgr_trspViaEdges: functions/pgr_trspViaEdges.md
+  - pgr_trspViaVertices: functions/pgr_trspViaVertices.md
+  - pgr_trsp_edge: functions/pgr_trsp_edge.md
+  - pgr_trsp_vertex: functions/pgr_trsp_vertex.md
 theme: readthedocs


### PR DESCRIPTION
@MarPetra @cvvergara I've fixed Mkdocs nav file adding all new functions markdown files to list. I've builded and uploaded to qgis.pgrouting.org (Although this PR is not merged you can already see updates in docs web page).
You can see that the button images are a little bit moved.
Thanks!