### PR TITLE
Drop QGIS v1 compatibility to support QGIS >= v3.24

### DIFF
--- a/connectors/postgis.py
+++ b/connectors/postgis.py
@@ -128,12 +128,12 @@ class Connection(DbConn.Connection):
         if not settings.contains("database"):  # non-existent entry?
             raise DbError('there is no defined database connection "%s".' % selected)
 
-        get_value_str = lambda x: str(settings.value(x) if Utils.isSIPv2() else settings.value(x).toString())
+        get_value_str = lambda x: str(settings.value(x))
         service, host, port, database, username, password = list(map(get_value_str, ["service", "host", "port", "database", "username", "password"]))
 
         # qgis1.5 use 'savePassword' instead of 'save' setting
-        isSave = settings.value("save") if Utils.isSIPv2() else settings.value("save").toBool()
-        isSavePassword = settings.value("savePassword") if Utils.isSIPv2() else settings.value("savePassword").toBool()
+        isSave = settings.value("save")
+        isSavePassword = settings.value("savePassword")
         if not (isSave or isSavePassword):
             (password, ok) = QInputDialog.getText(parent, "Enter password", 'Enter password for connection "%s":' % selected, QLineEdit.Password)
             if not ok: return

--- a/pgRoutingLayer_utils.py
+++ b/pgRoutingLayer_utils.py
@@ -72,25 +72,14 @@ def setTransformQuotes(args, srid, canvas_srid):
         args['transform_e'] = sql.SQL("")
 
 
-def isSIPv2():
-    '''Checks the version of SIP '''
-    return sip.getapi('QVariant') > 1
-
-
 def getStringValue(settings, key, value):
     ''' returns key and its corresponding value. example: ("interval",30). '''
-    if isSIPv2():
-        return settings.value(key, value, type=str)
-    else:
-        return settings.value(key, QVariant(value)).toString()
+    return settings.value(key, value, type=str)
 
 
 def getBoolValue(settings, key, value):
     ''' returns True if settings exist otherwise False. '''
-    if isSIPv2():
-        return settings.value(key, value, type=bool)
-    else:
-        return settings.value(key, QVariant(value)).toBool()
+    return settings.value(key, value, type=bool)
 
 
 def getDestinationCrs(mapCanvas):

--- a/pgRoutingLayer_utils.py
+++ b/pgRoutingLayer_utils.py
@@ -88,12 +88,12 @@ def getDestinationCrs(mapCanvas):
 
 
 def getCanvasSrid(crs):
-    ''' Returns SRID based on QGIS version. '''
+    ''' Returns SRID. '''
     return crs.postgisSrid()
 
 
 def createFromSrid(crs, srid):
-    ''' Creates EPSG crs for QGIS version 1 or Creates Spatial reference system based of SRID for QGIS version 2. '''
+    ''' Creates Spatial reference system based of SRID. '''
     return crs.createFromSrid(srid)
 
 

--- a/tests/Test_utils.py
+++ b/tests/Test_utils.py
@@ -62,9 +62,6 @@ class TestUtils(unittest.TestCase):
         utils.setEndPoint(geomType,args)
         self.assertEqual(args['endpoint'], 'ST_EndPoint(ST_GeometryN(test_geom, 1))')
 
-    def test_isSIPv2(self):
-        self.assertTrue(utils.isSIPv2())
-
     def test_getStringValue(self):
         setting = QSettings()
         setting.setValue('/pgRoutingLayer/Database', 99)


### PR DESCRIPTION
Fixes #138.

Changes proposed in this pull request:
- Drop `isSIPv2` function which was for QGIS v1 compatibility.
  - I created `isSIPv2` function was for QGIS v1 and v2 compatibility, but it's not necessary to support both v1 and v2 versions anymore.
    - [API changes for version 20 - QGIS Application - QGIS Issue Tracking](https://issues.qgis.org/projects/qgis/wiki/Python_plugin_API_changes_from_18_to_20)
    - [QGIS-2.x support by sanak · Pull Request #7 · anitagraser/pgRoutingLayer](https://github.com/anitagraser/pgRoutingLayer/pull/7/files#diff-2038a38745389e7d1683485d212659afc71500bc71b5eb09e4c4ee9d0ac2ed99)
- Modify util srid function comments which mentioned QGIS versions (v1 and v2).


@pgRouting/admins
