### PR TITLE
Catch "connectors.postgis.DbError" exception

### DIFF
--- a/pgRoutingLayer.py
+++ b/pgRoutingLayer.py
@@ -35,8 +35,10 @@ from qgis.PyQt.QtGui import QColor, QIcon, QIntValidator, QDoubleValidator, QReg
 from qgis.PyQt.QtWidgets import QAction, QApplication, QMessageBox
 from qgis.core import QgsRectangle, QgsCoordinateReferenceSystem, QgsCoordinateTransform
 from qgis.core import QgsProject, QgsGeometry, QgsWkbTypes
+from qgis.core import Qgis
 from qgis.gui import QgsVertexMarker, QgsRubberBand, QgsMapToolEmitPoint
 from pgRoutingLayer import dbConnection
+from pgRoutingLayer.connectors.postgis import DbError as PgDbError
 from pgRoutingLayer import pgRoutingLayer_utils as Utils
 from pgRoutingLayer.utilities import pgr_queries as PgrQ
 import os
@@ -274,8 +276,8 @@ class PgRoutingLayer:
                 if (Utils.getPgrVersion(con) != 0):
                     self.dock.comboConnections.addItem(dbname)
 
-            except dbConnection.DbError as e:
-                Utils.logMessage("dbname:" + dbname + ", " + e.msg)
+            except PgDbError as e:
+                Utils.logMessage("dbname:" + dbname + ", " + e.msg, Qgis.Critical)
 
             finally:
                 if db and db.con:


### PR DESCRIPTION
Fixes #140.

Changes proposed in this pull request:
- [Fix to catch "connectors.postgis.DbError"](https://github.com/pgRouting/pgRoutingLayer/commit/d0ab11237f756886be75006c6b33215333d3c47c)

The issue's cause was catching parent `dbConnector.DbError` side, so I fixed to catch child `connectors.postgis.DbError` side with minimum import.
Also, I changed the log level from default `Qgis.Info` to `Qgis.Critical` for user's awareness.

@pgRouting/admins
