### PR TITLE
Catch KeyError in openHelp method

### DIFF
--- a/pgRoutingLayer.py
+++ b/pgRoutingLayer.py
@@ -1260,7 +1260,7 @@ class PgRoutingLayer:
         except psycopg2.DatabaseError:
             # database didn't have pgrouting
             return 0
-        except SystemError:
+        except (SystemError, KeyError):
             return 0
         url = QUrl('https://docs.pgrouting.org/' + str(version) + '/en/' + function + '.html')
         try:


### PR DESCRIPTION
Fixes #143.

Changes proposed in this pull request:
- Catch KeyError in openHelp method

@pgRouting/admins
