### PR TITLE
Add LICENSE to zip

### DIFF
--- a/pb_tool.cfg
+++ b/pb_tool.cfg
@@ -24,7 +24,7 @@ compiled_ui_files:
 resource_files: resources.qrc
 
 # Other files required for the plugin
-extras: metadata.txt icon.png
+extras: metadata.txt icon.png LICENSE
 
 # Other directories to be deployed with the plugin.
 # These must be subdirectories under the plugin directory


### PR DESCRIPTION
To solve the following uploading plugin time error, adding `LICENSE` to zip seems to be necessary.
<img width="1019" height="514" alt="pgRoutingLayer-plugin-upload-error" src="https://github.com/user-attachments/assets/99db1d33-4c28-453c-a04d-0e9c7161f9ed" />

After this changes and refreshing zip file, I could upload the plugin.
In my memory, deploying take a certain time, so let's wait for the result.
<img width="951" height="167" alt="pgRoutingLayer-plugin-upload-waiting-for-connect" src="https://github.com/user-attachments/assets/65a4605f-1873-4d8a-a870-33f53aa53d81" />






<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated plugin deployment configuration to include LICENSE file in distribution package.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->